### PR TITLE
This branche introduce gcc 4.9 and all versions available since then,…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,145 +1,334 @@
 language: cpp
 
-dist: trusty
-sudo: true
-
 branches:
   only:
     - master
 
 matrix:
+  allow_failures:
+    - env:
+      - TESTGROUP=CANFAIL
+
   include:
-  # Linux clang builds
+
+  # - os: linux
+  #   dist: trusty
+  #   compiler: clang
+  #   env:
+  #     - COMPILER_NAME=clang
+  #     - COMPILER_VERSION=3.3
+  #     - TESTGROUP=CANFAIL
+
   - os: linux
+    dist: trusty
     compiler: clang
     env:
-      - COMPILER=clang++-4.0
-      - COV_TOOL=llvm-cov-4.0
-      - COV_TOOL_ARGS=gcov
-    addons:
-      apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0']
-        packages: [ 'cmake', 'clang-4.0', 'llvm-4.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov' ]
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=3.4
+      - TESTGROUP=CANFAIL
 
   - os: linux
+    dist: trusty
     compiler: clang
     env:
-      - COMPILER=clang++-5.0
-      - COV_TOOL=llvm-cov-5.0
-      - COV_TOOL_ARGS=gcov
-    addons:
-      apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
-        packages: [ 'cmake', 'clang-5.0', 'llvm-5.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov' ]
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=3.5
+      - TESTGROUP=CANFAIL
 
   - os: linux
+    dist: trusty
     compiler: clang
     env:
-      - COMPILER=clang++-6.0
-      - COV_TOOL=llvm-cov-6.0
-      - COV_TOOL_ARGS=gcov
-    addons:
-      apt:
-        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0']
-        packages: [ 'cmake', 'clang-6.0', 'llvm-6.0-tools', 'libstdc++-6-dev', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov' ]
-
-  # Linux GCC builds
-  - os: linux
-    compiler: gcc
-    env:
-      - COMPILER=g++-4.9
-      - COV_TOOL=gcov-4.9
-      - COV_TOOL_ARGS=
-    addons:
-      apt:
-        sources: ['ubuntu-toolchain-r-test']
-        packages: ['g++-4.9', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov']
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=3.6
 
   - os: linux
-    compiler: gcc
+    dist: trusty
+    compiler: clang
     env:
-      - COMPILER=g++-5
-      - COV_TOOL=gcov-5
-      - COV_TOOL_ARGS=
-    addons:
-      apt:
-        sources: ['ubuntu-toolchain-r-test']
-        packages: ['g++-5', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov']
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=3.7
 
   - os: linux
-    compiler: gcc
+    dist: trusty
+    compiler: clang
     env:
-      - COMPILER=g++-6
-      - COV_TOOL=gcov-6
-      - COV_TOOL_ARGS=
-    addons:
-      apt:
-        sources: ['ubuntu-toolchain-r-test']
-        packages: ['g++-6', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov']
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=3.8
 
   - os: linux
-    compiler: gcc
+    dist: trusty
+    compiler: clang
     env:
-      - COMPILER=g++-7
-      - COV_TOOL=gcov-7
-      - COV_TOOL_ARGS=
-    addons:
-      apt:
-        sources: ['ubuntu-toolchain-r-test']
-        packages: ['g++-7', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov']
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=3.9
 
   - os: linux
+    dist: trusty
+    compiler: clang
+    env:
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=4.0
+
+  - os: linux
+    dist: trusty
+    compiler: clang
+    env:
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=5.0
+
+  - os: linux
+    dist: trusty
+    compiler: clang
+    env:
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=6.0
+
+  - os: linux
+    dist: trusty
+    compiler: clang
+    env:
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=7
+
+  - os: linux
+    dist: trusty
+    compiler: clang
+    env:
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=8
+
+  # - os: linux
+  #   dist: trusty
+  #   compiler: gcc
+  #   env:
+  #     - COMPILER_NAME=gcc
+  #     - COMPILER_VERSION=4.4
+  #     - TESTGROUP=CANFAIL
+
+  # - os: linux
+  #   dist: trusty
+  #   compiler: gcc
+  #   env:
+  #     - COMPILER_NAME=gcc
+  #     - COMPILER_VERSION=4.6
+  #     - TESTGROUP=CANFAIL
+
+  # - os: linux
+  #   dist: trusty
+  #   compiler: gcc
+  #   env:
+  #     - COMPILER_NAME=gcc
+  #     - COMPILER_VERSION=4.7
+  #     - TESTGROUP=CANFAIL
+
+  # - os: linux
+  #   dist: trusty
+  #   compiler: gcc
+  #   env:
+  #     - COMPILER_NAME=gcc
+  #     - COMPILER_VERSION=4.8
+  #     - TESTGROUP=CANFAIL
+
+  - os: linux
+    dist: trusty
     compiler: gcc
     env:
-      - COMPILER=g++-8
-      - COV_TOOL=gcov-8
-      - COV_TOOL_ARGS=
-    addons:
-      apt:
-        sources: ['ubuntu-toolchain-r-test']
-        packages: ['g++-8', 'libssl-dev', 'libcurl4-openssl-dev', 'gdb', 'lcov']
+      - COMPILER_NAME=gcc
+      - COMPILER_VERSION=4.9
 
-install:
-  - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
-  - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
+  - os: linux
+    dist: trusty
+    compiler: gcc
+    env:
+      - COMPILER_NAME=gcc
+      - COMPILER_VERSION=5
+
+  - os: linux
+    dist: trusty
+    compiler: gcc
+    env:
+      - COMPILER_NAME=gcc
+      - COMPILER_VERSION=6
+
+  - os: linux
+    dist: trusty
+    compiler: gcc
+    env:
+      - COMPILER_NAME=gcc
+      - COMPILER_VERSION=7
+
+  - os: linux
+    dist: trusty
+    compiler: gcc
+    env:
+      - COMPILER_NAME=gcc
+      - COMPILER_VERSION=8
+
+  # - os: linux
+  #   dist: xenial
+  #   compiler: clang
+  #   env:
+  #     - COMPILER_NAME=clang
+  #     - COMPILER_VERSION=3.3
+  #     - TESTGROUP=CANFAIL
+
+  # - os: linux
+  #   dist: xenial
+  #   compiler: clang
+  #   env:
+  #     - COMPILER_NAME=clang
+  #     - COMPILER_VERSION=3.4
+  #     - TESTGROUP=CANFAIL
+
+  # - os: linux
+  #   dist: xenial
+  #   compiler: clang
+  #   env:
+  #     - COMPILER_NAME=clang
+  #     - COMPILER_VERSION=3.5
+  #     - TESTGROUP=CANFAIL
+
+  # - os: linux
+  #   dist: xenial
+  #   compiler: clang
+  #   env:
+  #     - COMPILER_NAME=clang
+  #     - COMPILER_VERSION=3.6
+
+  # - os: linux
+  #   dist: xenial
+  #   compiler: clang
+  #   env:
+  #     - COMPILER_NAME=clang
+  #     - COMPILER_VERSION=3.7
+
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env:
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=3.8
+
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env:
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=3.9
+
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env:
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=4.0
+
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env:
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=5.0
+
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env:
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=6.0
+
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env:
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=7
+
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env:
+      - COMPILER_NAME=clang
+      - COMPILER_VERSION=8
+
+  # - os: linux
+  #   dist: xenial
+  #   compiler: gcc
+  #   env:
+  #     - COMPILER_NAME=gcc
+  #     - COMPILER_VERSION=4.4
+  #     - TESTGROUP=CANFAIL
+
+  # - os: linux
+  #   dist: xenial
+  #   compiler: gcc
+  #   env:
+  #     - COMPILER_NAME=gcc
+  #     - COMPILER_VERSION=4.6
+  #     - TESTGROUP=CANFAIL
+
+  # - os: linux
+  #   dist: xenial
+  #   compiler: gcc
+  #   env:
+  #     - COMPILER_NAME=gcc
+  #     - COMPILER_VERSION=4.7
+  #     - TESTGROUP=CANFAIL
+
+  # - os: linux
+  #   dist: xenial
+  #   compiler: gcc
+  #   env:
+  #     - COMPILER_NAME=gcc
+  #     - COMPILER_VERSION=4.8
+  #     - TESTGROUP=CANFAIL
+
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env:
+      - COMPILER_NAME=gcc
+      - COMPILER_VERSION=4.9
+
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env:
+      - COMPILER_NAME=gcc
+      - COMPILER_VERSION=5
+
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env:
+      - COMPILER_NAME=gcc
+      - COMPILER_VERSION=6
+
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env:
+      - COMPILER_NAME=gcc
+      - COMPILER_VERSION=7
+
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env:
+      - COMPILER_NAME=gcc
+      - COMPILER_VERSION=8
 
 before_script:
-  - export CXX=${COMPILER}
-  - cd ${TRAVIS_BUILD_DIR}
-
-  # Enable core dumps
-  - ulimit -c
-  - ulimit -a -S
-  - ulimit -a -H
-
-  # Print debug system information
-  - cat /proc/sys/kernel/core_pattern
-  - cat /etc/default/apport
-  - service --status-all || true
-  - initctl list || true
-
-  # Debug build
-  - cmake -H.
-    -BBuild-Debug
-    -DCMAKE_BUILD_TYPE=Debug
-    -DPISTACHE_BUILD_EXAMPLES=true
-    -DPISTACHE_BUILD_TESTS=true
-    -DPISTACHE_SSL=true
-
-  # Release build
-  - cmake -H.
-    -BBuild-Release
-    -DCMAKE_BUILD_TYPE=Release
-    -DPISTACHE_SSL=true
+  # Bootraping environment and required packages
+  - cd $TRAVIS_BUILD_DIR
+  - . ./.travis/before_script.bash
 
 script:
-  - # Debug build
-  - cd Build-Debug
-  - make -j 2 all test ARGS="-V"
-
-  - # Release build
-  - cd ../Build-Release
-  - make -j 2
+  # Debug build
+  - make -C $TRAVIS_BUILD_DIR/build/debug -j $(nproc) all test VERBOSE=1 ARGS=-V
+  # Release build
+  - make -C $TRAVIS_BUILD_DIR/build/release -j $(nproc) all  VERBOSE=1 ARGS=-V
 
 after_failure:
   - ls -lta /var/crash
@@ -148,9 +337,8 @@ after_failure:
     gdb -c "$COREFILE" -ex "thread apply all bt" -ex "set pagination 0" -batch;
     fi
 
-
 after_success:
-- cd ../Build-Debug
+- cd $TRAVIS_BUILD_DIR/build/debug
 - sudo su -c "echo 'if [ \"\$1\" = \"-v\" ] ; then $COV_TOOL --version ; else $COV_TOOL $COV_TOOL_ARGS \$@ ; fi' > /usr/local/bin/cov-tool" && sudo chmod +x /usr/local/bin/cov-tool
 - lcov --capture --gcov-tool cov-tool --directory . --output-file coverage.info
 - lcov --remove coverage.info '/usr/*' '*tests/*' '*googletest-release-1.7.0/*' --output-file coverage.info

--- a/.travis/before_script.bash
+++ b/.travis/before_script.bash
@@ -1,0 +1,140 @@
+#!/bin/bash -ve
+
+export $(cat /etc/*release | grep DISTRIB_CODENAME)
+
+sudo apt-get update
+
+sudo apt-get install -y wget software-properties-common bc
+
+if [[ "$DISTRIB_CODENAME" = "trusty" ]]; then
+sudo su -c 'cat <<EOF > /etc/apt/sources.list.d/llvm.list
+deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.4 main
+deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.5 main
+deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.6 main
+deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.7 main
+deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main
+deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main
+deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main
+deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main
+deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-8 main
+EOF'
+fi
+
+if [[ "$DISTRIB_CODENAME" = "xenial" ]]; then
+sudo su -c 'cat <<EOF > /etc/apt/sources.list.d/llvm.list
+deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main
+deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main
+deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main
+deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main
+deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main
+EOF'
+fi
+
+if [[ "$DISTRIB_CODENAME" = "bionic" ]]; then
+sudo su -c 'cat <<EOF > /etc/apt/sources.list.d/llvm.list
+deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-5.0 main
+deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-6.0 main
+deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main
+deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main
+EOF'
+fi
+
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+
+# This updates libstdc++ to version 4.9 which makes this software compiles correctly in clang.
+# In Ubuntu Trusty this library will just works with g++-4.9 backport and so on.
+# It's impossible to build this in trusty without backports once Ubuntu trusty release was in
+# april 2014 and GCC at this time wasnt supporting C++14. In this case, third-party backports
+# as provided by ubuntu-toolchain-r/test are necessary to build this in ubuntu xenial and trusty
+# natively. Here we configure this backports repository and install g++-4.9.
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+
+# This will fix llvm 3.4 and 3.6
+sudo apt-get update
+sudo apt-get install -y g++-4.9
+
+if [[ "$COMPILER_NAME" = "clang" ]]; then
+    
+    export C_COMPILER_PACKAGE=clang-$COMPILER_VERSION
+    export C_COMPILER_BIN=clang-$COMPILER_VERSION
+    export CPP_COMPILER_PACKAGE=
+    export CPP_COMPILER_BIN=clang++-$COMPILER_VERSION
+    export COV_TOOL_BIN=llvm-cov-$COMPILER_VERSION
+    if [ ! -z "$(sudo apt-cache search llvm-$COMPILER_VERSION-tools)" ]; then export COV_TOOL_PACKAGE="$COV_TOOL_PACKAGE llvm-$COMPILER_VERSION-tools"; fi
+    if [ ! -z "$(sudo apt-cache search llvm-$COMPILER_VERSION)" ]; then export COV_TOOL_PACKAGE="$COV_TOOL_PACKAGE llvm-$COMPILER_VERSION-tools"; fi
+    export COV_TOOL_ARGS=gcov
+
+    if [[ $COMPILER_VERSION = 3.3 ]]; then
+        export C_COMPILER_BIN=clang
+        export CPP_COMPILER_BIN=clang++
+    fi
+
+elif [[ "$COMPILER_NAME" = "gcc" ]]; then
+    export C_COMPILER_PACKAGE=gcc-$COMPILER_VERSION
+    export C_COMPILER_BIN=gcc-$COMPILER_VERSION
+    export CPP_COMPILER_PACKAGE=g++-$COMPILER_VERSION
+    export CPP_COMPILER_BIN=g++-$COMPILER_VERSION
+    export COV_TOOL_BIN=gcov-$COMPILER_VERSION
+    export COV_TOOL_PACKAGE=gcov-$COMPILER_VERSION
+fi
+
+export CC=$C_COMPILER_BIN
+export CXX=$CPP_COMPILER_BIN
+
+sudo apt-get update
+
+sudo apt-get install -y \
+    coreutils \
+    apparmor-profiles \
+    libssl-dev \
+    libcurl4-openssl-dev \
+    gdb \
+    valgrind \
+    lcov \
+    python-pip \
+    python3-pip \
+    git \
+    $C_COMPILER_PACKAGE \
+    $CPP_COMPILER_PACKAGE \
+    $CPP_STDLIB_PACKAGE
+
+sudo python -m pip install --upgrade pip
+sudo python3 -m pip install --upgrade pip
+
+sudo pip3 install cmake
+
+# Enable core dumps
+ulimit -c
+ulimit -a -S
+ulimit -a -H
+
+# Print debug system information
+cat /proc/sys/kernel/core_pattern
+cat /etc/default/apport || true
+service --status-all || true
+initctl list || true
+
+mkdir -p $TRAVIS_BUILD_DIR/build/debug
+mkdir -p $TRAVIS_BUILD_DIR/build/release
+
+cd $TRAVIS_BUILD_DIR/build/debug
+
+# Debug build
+cmake -B$TRAVIS_BUILD_DIR/build/debug \
+    -DCMAKE_BUILD_TYPE=debug \
+    -DPISTACHE_BUILD_EXAMPLES=true \
+    -DPISTACHE_BUILD_TESTS=true \
+    -DPISTACHE_SSL=true \
+    -DCMAKE_C_COMPILER=$CC \
+    -DCMAKE_CXX_COMPILER=$CXX $TRAVIS_BUILD_DIR
+
+cd $TRAVIS_BUILD_DIR/build/release
+
+# Release build
+cmake -B$TRAVIS_BUILD_DIR/build/release \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DPISTACHE_SSL=true \
+    -DCMAKE_C_COMPILER=$CC \
+    -DCMAKE_CXX_COMPILER=$CXX $TRAVIS_BUILD_DIR
+
+cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
… clang since 3.4 in trusty and clang 3.8 in xenial.

Clang 3.4 and 3.6 is not building in xenial for an unknown reason.
GCC before 4.9 doesn't have support to C++14 standard.